### PR TITLE
Adding files property to package.json for better published tarball size

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,10 @@
     "module",
     "package"
   ],
+  "files": [
+    "bin",
+    "lib"
+  ],
   "author": "Joel Denning",
   "license": "MPL-2.0",
   "bugs": {


### PR DESCRIPTION
`npm pack` is a way of seeing the tarball that npm would publish without actually publishing it.

Before this PR:
<img width="319" alt="image" src="https://user-images.githubusercontent.com/5524384/66097772-f1eb6a80-e55c-11e9-90a4-3217b713f3b0.png">

After this PR:
<img width="313" alt="image" src="https://user-images.githubusercontent.com/5524384/66097789-fdd72c80-e55c-11e9-87e4-c19f0696c4c6.png">

See https://docs.npmjs.com/files/package.json#files for why this code change makes the tarball so much smaller -- it's because we aren't including the `examples` dir in the tarball anymore