### PR TITLE
Adding ability to override the current working directory

### DIFF
--- a/bin/packmap-cli.js
+++ b/bin/packmap-cli.js
@@ -14,6 +14,10 @@ program.option(
   "--override-map <overrideMap>",
   "path to importmap which overrides the generated map"
 );
+program.option(
+  "--cwd <cwd>",
+  "override the path to use as the current working directory"
+);
 
 program.parse(process.argv);
 

--- a/lib/packmap.js
+++ b/lib/packmap.js
@@ -3,15 +3,16 @@ const path = require("path");
 const sortObject = require("sort-object-keys");
 
 module.exports = async function packmap(opts) {
+  const cwd = opts.cwd || process.cwd();
   const normalizedOutdir = path.normalize(opts.outdir);
   await fs.remove(normalizedOutdir);
   await fs.ensureDir(normalizedOutdir);
-  const packageJsonPath = path.resolve(process.cwd(), opts.package);
+  const packageJsonPath = path.resolve(cwd, opts.package);
   const packageJson = require(packageJsonPath);
   const importMap = await traversePackage(packageJson);
 
   if (opts.overrideMap) {
-    const overridingMapPath = path.resolve(process.cwd(), opts.overrideMap);
+    const overridingMapPath = path.resolve(cwd, opts.overrideMap);
     if (await fs.pathExists(overridingMapPath)) {
       const overridingMap = require(overridingMapPath);
       Object.assign(importMap.imports, overridingMap.imports);
@@ -47,7 +48,7 @@ module.exports = async function packmap(opts) {
 
         const packageDir = path.dirname(
           require.resolve(dependency + "/package.json", {
-            paths: [process.cwd()]
+            paths: [cwd]
           })
         );
         const depPackageJson = require(path.resolve(


### PR DESCRIPTION
@rrameshbtech can you take a look at this?

It will be used in tests, but also will likely just be useful for people who want to control the root directory that is used to resolve all the files that packmap reads from and creates.