### PR TITLE
Print the list of dependencies imported by each package

### DIFF
--- a/bin/packmap-cli.js
+++ b/bin/packmap-cli.js
@@ -18,6 +18,7 @@ program.option(
   "--cwd <cwd>",
   "override the path to use as the current working directory"
 );
+program.option("-v, --verbose", "print lots of stuff");
 
 program.parse(process.argv);
 

--- a/lib/packmap.js
+++ b/lib/packmap.js
@@ -17,8 +17,10 @@ module.exports = async function packmap(opts) {
   const packageJson = readPackageJson(packageJsonPath);
   const importMap = await traversePackage(packageJson);
 
-  log(`Processed dependency tree`);
-  log(depTree);
+  if (opts.verbose) {
+    log(`Processed dependency tree`);
+    log(depTree);
+  }
 
   if (opts.overrideMap) {
     const overridingMapPath = path.resolve(cwd, opts.overrideMap);
@@ -47,7 +49,9 @@ module.exports = async function packmap(opts) {
         if (dependency.startsWith("@types/")) {
           return;
         }
-        log(`processing dependency ${dependency}`);
+        if (opts.verbose) {
+          log(`processing dependency ${dependency}`);
+        }
 
         let overrides = {};
         try {

--- a/lib/packmap.js
+++ b/lib/packmap.js
@@ -8,6 +8,7 @@ module.exports = async function packmap(opts) {
   if (!path.isAbsolute(cwd)) {
     cwd = path.resolve(process.cwd(), cwd);
   }
+  const depTree = {};
   const log = opts.log || function() {};
   const normalizedOutdir = path.normalize(opts.outdir);
   await fs.remove(normalizedOutdir);
@@ -15,6 +16,9 @@ module.exports = async function packmap(opts) {
   const packageJsonPath = path.resolve(cwd, opts.package);
   const packageJson = readPackageJson(packageJsonPath);
   const importMap = await traversePackage(packageJson);
+
+  log(`Processed dependency tree`);
+  log(depTree);
 
   if (opts.overrideMap) {
     const overridingMapPath = path.resolve(cwd, opts.overrideMap);
@@ -37,6 +41,7 @@ module.exports = async function packmap(opts) {
 
   function traversePackage(packageJson, importMap = { imports: {} }) {
     const dependencies = Object.keys(packageJson.dependencies || {});
+    depTree[packageJson.name] = dependencies;
     return Promise.all(
       dependencies.map(dependency => {
         if (dependency.startsWith("@types/")) {


### PR DESCRIPTION
Sample output

```
...
processing dependency @openmrs/esm-root-config                                                                                                                                                                                                                                                                        
processing dependency rxjs                                                                                                                                                                                                                                                                                            
processing dependency single-spa                                                                                                                                                                                                                                                                                      
processing dependency @openmrs/esm-styleguide                                                                                                                                                                                                                                                                         
processing dependency import-map-overrides                                                                                                                                                                                                                                                                            
processing dependency react                                                                                                                                                                                                                                                                                           
processing dependency react-dom                                                                                                                                                                                                                                                                                       
processing dependency rxjs                                                                                                                                                                                                                                                                                            
processing dependency single-spa                                                                                                                                                                                                                                                                                      
processing dependency systemjs                                                                                                                                                                                                                                                                                        
Generated import-map overridden by "./override-import-map.json"                                                                                                                                                                                                                                                       
Processed dependency tree                                                                                                                                                                                                                                                                                             
{ 'openmrs-example':                                                                                                                                                                                                                                                                                                  
   [ '@openmrs/esm-api',                                                                                                                                                                                                                                                                                              
     '@openmrs/esm-devtools',                                                                                                                                                                                                                                                                                         
     '@openmrs/esm-error-handling',                                                                                                                                                                                                                                                                                   
     '@openmrs/esm-home',                                                                                                                                                                                                                                                                                             
     '@openmrs/esm-login',                                                                                                                                                                                                                                                                                            
     '@openmrs/esm-primary-navigation',                                                                                                                                                                                                                                                                               
     '@openmrs/esm-root-config',                                                                                                                                                                                                                                                                                      
     '@openmrs/esm-styleguide',                                                                                                                                                                                                                                                                                       
     'import-map-overrides',                                                                                                                                                                                                                                                                                          
     'react',                                                                                                                                                                                                                                                                                                         
     'react-dom',                                                                                                                                                                                                                                                                                                     
     'rxjs',                                                                                                                                                                                                                                                                                                          
     'single-spa',                                                                                                                                                                                                                                                                                                    
     'systemjs' ],                                                                                                                                                                                                                                                                                                    
  '@openmrs/esm-api': [ 'react', 'rxjs' ],                                                                                                                                                                                                                                                                            
  react: [],                                                                                                                                                                                                                                                                                                          
  rxjs: [],
  '@openmrs/esm-devtools':
   [ '@types/react',
     '@types/react-dom',
     '@types/single-spa-react',
     '@types/systemjs',
     'react',
     'react-dom' ],
  'react-dom': [],
  '@openmrs/esm-error-handling': [ '@openmrs/esm-styleguide' ],
  '@openmrs/esm-styleguide': [],
  '@openmrs/esm-home':
   [ '@openmrs/esm-api',
     '@types/react-router',
     'react',
     'react-dom' ],
  '@openmrs/esm-login':
   [ '@openmrs/esm-api',
     '@types/react',
     '@types/react-dom',
     'react',
     'react-dom',
     'rxjs' ],
  '@openmrs/esm-primary-navigation': [ '@openmrs/esm-api', 'react', 'react-dom', 'rxjs' ],
  '@openmrs/esm-root-config': [ 'rxjs', 'single-spa' ],
  'single-spa': [],
  'import-map-overrides': [],
  systemjs: [] }
packmap finished in 53ms. Check the openmrs/frontend directory.
```