### PR TITLE
Nested Exclusions

### DIFF
--- a/lib/packmap.js
+++ b/lib/packmap.js
@@ -134,7 +134,7 @@ module.exports = async function packmap(opts) {
           : fs.copy(dirToCopy, destDir);
         return Promise.all([
           copyPromise,
-          traversePackage(depPackageJson, importMap)
+          traversePackage(depPackageJson, importMap, excludePackages)
         ]);
       })
     ).then(() => importMap);


### PR DESCRIPTION
Right now in the traversal the exclusions are not passed on. I think we should pass them on to allow nested exclusions.

Of course, this assumes somebody who actively *excludes* a module knows that it will be excluded even if it appears as a dependency of a dependency.

Not sure if it was intentionally not done or just overlooked. Any comment appreciated.

(I required this to make the new import map generation work; otherwise we had quite a lot of unwanted dependencies in the import map)